### PR TITLE
Add first test, import modules on load event, reenable GitHub Actions

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,12 +1,12 @@
 name: Run Tests
 
 on:
-  #push:
-  #  branches: [ "main" ]
-  #  paths-ignore: [ "**.md", "**.txt" ]
-  #pull_request:
-  #  branches: [ "main" ]
-  #  paths-ignore: [ "**.md", "**.txt" ]
+  push:
+    branches: [ "main" ]
+    paths-ignore: [ "**.md", "**.txt" ]
+  pull_request:
+    branches: [ "main" ]
+    paths-ignore: [ "**.md", "**.txt" ]
   workflow_dispatch:
 
 jobs:

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Test Page for TestPageOpener</title>
+    <script type="module" src="./test-modules/main.js"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/index.js
+++ b/index.js
@@ -331,9 +331,13 @@ class JsdomPageOpener {
           'load', {bubbles: false, cancelable: false}
         ))
       }
-      document.addEventListener(
-        'DOMContentLoaded', importModulesOnEvent, {once: true}
-      )
+
+      // If the page has other resources, like a stylesheet, it may still be
+      // loading (document.readyState === "loading"). If not, it may already
+      // have fired DOMContentLoaded (document.readyState === "interactive").
+      // Either way, both will always fire before importModules() resolves, so
+      // unconditionally register a "load" handler.
+      window.addEventListener('load', importModulesOnEvent, {once: true})
     })
   }
 }

--- a/test-modules/app.js
+++ b/test-modules/app.js
@@ -1,0 +1,16 @@
+/* eslint-env browser */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+const HELLO_URL = 'https://en.wikipedia.org/wiki/%22Hello,_World!%22_program'
+
+export default class App {
+  init({ appElem }) {
+    const t = document.createElement('template')
+    t.innerHTML = `<p><a href="${HELLO_URL}">Hello, World!</a></p>`
+    appElem.appendChild(t.content)
+  }
+}

--- a/test-modules/main.js
+++ b/test-modules/main.js
@@ -1,0 +1,14 @@
+/* eslint-env browser */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import App from './app.js'
+
+document.addEventListener(
+  'DOMContentLoaded',
+  () => new App().init({ appElem: document.querySelector('#app') }),
+  { once: true }
+)

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,0 +1,22 @@
+/* eslint-env browser, node, jest, vitest */
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+import { afterEach, describe, expect, test } from 'vitest'
+import { PageOpener } from '../index.js'
+
+describe('PageOpener', () => {
+  const opener = new PageOpener('/basedir/')
+  afterEach(() => opener.closeAll())
+
+  test('contains the "Hello, World!" placeholder', async () => {
+    const { document } = await opener.open('index.html')
+    const appElem = document.querySelector('#app')
+    const linkElem = document.querySelector('#app p a')
+
+    expect(appElem.textContent).toContain('Hello, World!')
+    expect(linkElem.href).toContain('%22Hello,_World!%22')
+  })
+})


### PR DESCRIPTION
This first test closely resembles the original test from mbland/tomcat-servlet-testing-example. In fact, it _still_ looks a lot like it, except that strcalc/src/main/frontend/main.test.js uses a Page Object. Once this module is published, both that test and this specific new test will continue to closely resemble one another.

One update to the original JsdomPageOpener that this test required was to register the module importer as a listener for the "load" event, not "DOMContentLoaded". I discovered that the tomcat-servlet-testing-example original loaded a page containing a stylesheet, which caused jsdom not to have fired "DOMContentLoaded", and document.readyState would be "loading". The index.html in this test doesn't load any other resources, so "DOMContentLoaded" fires and document.readyState is "interactive" before JSDOM.fromFile() even returns.

The solution was to register the importer listener for "load" instead. This event would already fire before the standalone importModules() returned, as explained in the long comment updated in this commit.

With this first test now in place, I'm also reenabling GitHub Actions.