### PR TITLE
Replace PageOpener.getImpl with PageOpener.create

### DIFF
--- a/test/main.test.js
+++ b/test/main.test.js
@@ -4,11 +4,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-import { afterEach, describe, expect, test } from 'vitest'
+import { afterEach, beforeAll, describe, expect, test } from 'vitest'
 import { PageOpener } from '../index.js'
 
 describe('PageOpener', () => {
-  const opener = new PageOpener('/basedir/')
+  let opener
+
+  beforeAll(async () => opener = await PageOpener.create('/basedir/'))
   afterEach(() => opener.closeAll())
 
   test('contains the "Hello, World!" placeholder', async () => {


### PR DESCRIPTION
Decided that I liked the idea of injecting the implementation using a static factory function instead of instantiating it on demand.

This required instantiating it in the test during beforeAll() instead of describe(), since describe() can't be async. Small price to pay.