### PR TITLE
Add JsdomPageOpener test

### DIFF
--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -84,7 +84,7 @@ export default class JsdomPageOpener {
    * @throws if importing any ECMAScript modules fails
    */
   #importModules(window, document) {
-    return new Promise(resolve => {
+    return new Promise((resolve, reject) => {
       const importModulesOnEvent = async () => {
         // The jsdom docs advise against setting global properties, but we don't
         // really have another option given any module may access window and/or
@@ -116,7 +116,9 @@ export default class JsdomPageOpener {
         // window and document from globalThis.
         globalThis.window = window
         globalThis.document = document
-        await importModules(document)
+
+        try { await importModules(document) }
+        catch (err) { reject(err) }
 
         // Manually firing DOMContentLoaded again after loading modules
         // approximates the requirement that modules execute before
@@ -157,6 +159,6 @@ function importModules(doc) {
   const modules = Array.from(doc.querySelectorAll('script[type="module"]'))
   return Promise.all(modules.filter(m => m.src).map(async m => {
     try { await import(m.src) }
-    catch (err) { throw Error(`error importing ${m.src}: ${err}`) }
+    catch (err) { throw new Error(`error importing ${m.src}: ${err}`) }
   }))
 }

--- a/test-modules/error.html
+++ b/test-modules/error.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Test Page for JsdomPageOpener module loading errors</title>
+    <script type="module" src="./error.js"></script>
+  </head>
+  <body>
+    <div id="app"></div>
+  </body>
+</html>

--- a/test-modules/error.js
+++ b/test-modules/error.js
@@ -1,0 +1,2 @@
+/* This module tests the JsdomPageOpener error handling. */
+throw new Error('test error')

--- a/test-modules/index.html
+++ b/test-modules/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Test Page for TestPageOpener</title>
-    <script type="module" src="./test-modules/main.js"></script>
+    <script type="module" src="./main.js"></script>
   </head>
   <body>
     <div id="app"></div>

--- a/test/jsdom.test.js
+++ b/test/jsdom.test.js
@@ -1,0 +1,24 @@
+/* eslint-env browser, node, jest, vitest */
+
+import JsdomPageOpener from '../lib/jsdom'
+import { beforeAll, describe, expect, test } from 'vitest'
+
+describe.skipIf(globalThis.window !== undefined)('JsdomPageOpener', () => {
+  let opener
+  let pathToFileURL
+
+  beforeAll(async () => {
+    const urlModule = await import('node:url')
+    opener = new JsdomPageOpener(await import('jsdom'))
+    pathToFileURL = urlModule.pathToFileURL
+  })
+
+  test('reports module loading errors', async () => {
+    const pagePath = './test-modules/error.html'
+    const moduleUrl = pathToFileURL('./test-modules/error.js')
+
+    await expect(() => opener.open('unused', pagePath)).rejects
+      .toThrowError(`error importing modules from ${pagePath}: ` +
+        `Error: error importing ${moduleUrl.href}: Error: test error`)
+  })
+})

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -14,7 +14,7 @@ describe('PageOpener', () => {
   afterEach(() => opener.closeAll())
 
   test('loads page with module successfully', async () => {
-    const { document } = await opener.open('index.html')
+    const { document } = await opener.open('test-modules/index.html')
     const appElem = document.querySelector('#app')
     const linkElem = document.querySelector('#app p a')
 
@@ -30,9 +30,8 @@ describe('PageOpener', () => {
     expect(newOpener('/basedir')).toThrow(prefix + '"/basedir"')
   })
 
-  test('open() throws if page path starts with \'/\'', async() => {
-    await expect(opener.open('/index.html')).rejects.toThrow(
-      'page path shouldn\'t start with \'/\', got: "/index.html"'
-    )
+  test('open() throws if page path starts with \'/\'', async () => {
+    await expect(opener.open('/index.html')).rejects
+      .toThrow('page path shouldn\'t start with \'/\', got: "/index.html"')
   })
 })


### PR DESCRIPTION
This covers the error handling parts of JsdomPageOpener, and actually caught a subtle bug in #importModules.

Because the returned Promise wrapped an event handler, the Error thrown from the standalone importModules() wasn't caught and rejected as expected.

The fix was to add a `reject` argument to the Promise function, wrap importModules() in a try/catch, and call `reject` with the caught error.