### PR TITLE
Refactor BrowserPageOpener, add test

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-/* eslint-env browser, node */
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -28,6 +27,14 @@ export class PageOpener {
     this.#opened = []
   }
 
+  /**
+   * Creates a new PageOpener instance.
+   *
+   * Prefer this to calling `new PageOpener`.
+   * @param {string} basePath - base path of the application under test
+   * @returns {PageOpener} - a new PageOpener initialized to open pages in the
+   *   current test environment, either via Jsdom or the browser
+   */
   static async create(basePath) {
     const impl = globalThis.window ?
       new BrowserPageOpener(globalThis.window) :
@@ -51,6 +58,9 @@ export class PageOpener {
     return page
   }
 
+  /**
+   * Closes the window object for all currently opened pages
+   */
   closeAll() {
     this.#opened.forEach(p => p.close())
     this.#opened = []

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,21 +1,32 @@
 /* eslint-env browser */
 
-import libCoverage from 'istanbul-lib-coverage'
+import { createCoverageMap } from 'istanbul-lib-coverage'
 import { OpenedPage } from './types'
 
+/**
+ * Returns the window and document from a browser-opened HTML file.
+ *
+ * As all modern browsers fully support JavaScript modules, there are no caveats
+ * or restrictions on any module import features. There's no requirement that a
+ * page that can open in the browser using this class needs to be compatible
+ * with JsdomPageOpener. However, it's likely best to design pages to be
+ * compatible with JsdomPageOpener as well.
+ */
 export default class BrowserPageOpener {
   #window
   #coverageKey
 
   constructor(window) {
-    this.#window = window
-    this.#coverageKey = BrowserPageOpener.getCoverageKey(window)
-  }
+    const covKey = getCoverageKey(window)
 
-  static getCoverageKey(globalObj) {
-    const foundKey = Object.getOwnPropertyNames(globalObj)
-      .find(n => /_+.*coverage_+/i.test(n))
-    return foundKey || '__coverage__'
+    this.#window = window
+    this.#coverageKey = covKey
+
+    // Unconditionally create a coverage object, even if not collecting
+    // coverage. There's no harm in this, and it avoids a coverage gap for a
+    // condition that, by definition, would never execute when collecting
+    // coverage. We could use a directive to ignore that gap, but why bother.
+    window[covKey] = createCoverageMap(window[covKey])
   }
 
   /**
@@ -27,24 +38,33 @@ export default class BrowserPageOpener {
   async open(basePath, pagePath) {
     const w = this.#window.open(`${basePath}${pagePath}`)
     const close = () => {
-      this.#mergeCoverageStore(w)
+      this.#window[this.#coverageKey].merge(w[this.#coverageKey])
       w.close()
     }
+
     return new Promise(resolve => {
-      const listener = () => {
-        resolve({window: w, document: w.document, close})
-      }
+      const listener = () => resolve({window: w, document: w.document, close})
       w.addEventListener('load', listener, {once: true})
     })
   }
+}
 
-  // This is very specific to the Istanbul coverage provider.
-  #mergeCoverageStore(openedWindow) {
-    const covKey = this.#coverageKey
-    const thisCov = this.#window[covKey]
-    const combinedCov = libCoverage.createCoverageMap(thisCov)
+/**
+ * Default value returned by getCoverageKey()
+ */
+export const DEFAULT_COVERAGE_KEY = '__coverage__'
 
-    combinedCov.merge(openedWindow[covKey])
-    this.#window[covKey] = combinedCov.toJSON()
-  }
+/**
+ * Returns the key for the Istanbul coverage object within the global object
+ *
+ * Searches for a key that looks like `/_.*coverage_/i`, such as Istanbul's
+ * default `__coverage__` or Vitest's `__VITEST_COVERAGE__`. If such a key
+ * doesn't exist, will return DEFAULT_COVERAGE_KEY by default.
+ * @param {(object|Window)} globalObj - the global object (globalThis or window)
+ * @returns {string} - the key for the Istanbul coverage object
+ */
+export function getCoverageKey(globalObj) {
+  const foundKey = Object.getOwnPropertyNames(globalObj)
+    .find(n => /_.*coverage_/i.test(n))
+  return foundKey || DEFAULT_COVERAGE_KEY
 }

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -1,4 +1,4 @@
-/* eslint-env browser, node */
+/* eslint-env browser */
 
 import { OpenedPage } from './types'
 

--- a/test/browser.test.js
+++ b/test/browser.test.js
@@ -1,0 +1,14 @@
+import { DEFAULT_COVERAGE_KEY, getCoverageKey } from '../lib/browser'
+import { describe, expect, test } from 'vitest'
+
+describe('getCoverageKey', () => {
+  test('returns existing coverage key', () => {
+    expect(getCoverageKey({__coverage__: null})).toBe('__coverage__')
+    expect(getCoverageKey({__VITEST_COVERAGE__: null}))
+      .toBe('__VITEST_COVERAGE__')
+  })
+
+  test('returns default __coverage__ key if no existing key', () => {
+    expect(getCoverageKey({})).toBe(DEFAULT_COVERAGE_KEY)
+  })
+})

--- a/test/jsdom.test.js
+++ b/test/jsdom.test.js
@@ -1,5 +1,3 @@
-/* eslint-env browser, node, jest, vitest */
-
 import JsdomPageOpener from '../lib/jsdom'
 import { beforeAll, describe, expect, test } from 'vitest'
 

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -1,4 +1,3 @@
-/* eslint-env browser, node, jest, vitest */
 /*
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this


### PR DESCRIPTION
Extracted getCoverageKey into a standalone function and added a test for it. With this test, the entire package now has 100% test coverage.

The local current build commands don't merge the browser and jsdom coverage, but the Coveralls step in our GitHub Actions CI does.

Also adds a few more Jsdoc comments and removes unnecessary eslint directives.