### PR TITLE
Bump to 1.0.1, export default TestPageOpener

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ pnpm add -D test-page-opener
 
 ```js
 import { afterEach, beforeAll, describe, expect, test } from 'vitest'
-import { TestPageOpener } from 'test-page-opener'
+import TestPageOpener from 'test-page-opener'
 
 describe('TestPageOpener', () => {
   let opener

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ import { OpenedPage } from './lib/types'
  *
  * ```js
  * import { afterEach, beforeAll, describe, expect, test } from 'vitest'
- * import { TestPageOpener } from 'test-page-opener'
+ * import TestPageOpener from 'test-page-opener'
  *
  * describe('TestPageOpener', () => {
  *   let opener
@@ -33,7 +33,7 @@ import { OpenedPage } from './lib/types'
  * })
  * ```
  */
-export class TestPageOpener {
+export default class TestPageOpener {
   static #isConstructing = false
 
   #basePath

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-page-opener",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Enables an application's tests to open its own page URLs both in the browser and in Node.js using jsdom",
   "main": "index.js",
   "scripts": {

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -5,7 +5,7 @@
  */
 
 import { afterEach, beforeAll, describe, expect, test } from 'vitest'
-import { TestPageOpener } from '../index.js'
+import TestPageOpener from '../index.js'
 
 describe('TestPageOpener', () => {
   let opener


### PR DESCRIPTION
Allows direct import of TestPageOpener as intended.

There's always some little detail that you don't notice until after the first release.