### PR TITLE
Bump to v1.0.2, add .js extension to local imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import BrowserPageOpener from './lib/browser'
-import JsdomPageOpener from './lib/jsdom'
-import { OpenedPage } from './lib/types'
+import BrowserPageOpener from './lib/browser.js'
+import JsdomPageOpener from './lib/jsdom.js'
+import { OpenedPage } from './lib/types.js'
 
 /**
  * Enables tests to open an application's own page URLs both in the browser and

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -6,7 +6,7 @@
  */
 
 import { createCoverageMap } from 'istanbul-lib-coverage'
-import { OpenedPage } from './types'
+import { OpenedPage } from './types.js'
 
 /**
  * Returns the window and document from a browser-opened HTML file.

--- a/lib/jsdom.js
+++ b/lib/jsdom.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { OpenedPage } from './types'
+import { OpenedPage } from './types.js'
 
 /**
  * Returns window and document objects from a jsdom-parsed HTML file.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-page-opener",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Enables an application's tests to open its own page URLs both in the browser and in Node.js using jsdom",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
After installing v1.0.1 in a local copy of
mbland/tomcat-servlet-testing-example, running the tests against jsdom broke with:

```text
  FAIL  main.test.js [ main.test.js ]
  Error: Cannot find module
  '.../tomcat-servlet-testing-example/strcalc/src/main/frontend/node_modules/.pnpm/test-page-opener@1.0.1/node_modules/test-page-opener/lib/browser'
  imported from
  .../tomcat-servlet-testing-example/strcalc/src/main/frontend/node_modules/.pnpm/test-page-opener@1.0.1/node_modules/test-page-opener/index.js
  ⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯
  Serialized Error: {
    code: 'ERR_MODULE_NOT_FOUND',
    url: 'file:///.../tomcat-servlet-testing-example/strcalc/src/main/frontend/node_modules/.pnpm/test-page-opener@1.0.1/node_modules/test-page-opener/lib/browser'
  }
```

Running `pnpm link ../../../../../test-page-opener` and running the tests again worked, so I wouldn't've caught this before releasing v1.0.1, either.

And apparently this is quite a thing, especially impacting TypeScript users:

- https://www.google.com/search?q=node+import+requires+.js+extension
- https://github.com/nodejs/node/issues/46006
- https://nodejs.org/docs/latest-v18.x/api/esm.html#import-specifiers

So be it.