### PR TITLE
Bump to v1.0.3, fix istanbul-lib-coverage import

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -5,7 +5,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import { createCoverageMap } from 'istanbul-lib-coverage'
+import libCoverage from 'istanbul-lib-coverage'
 import { OpenedPage } from './types.js'
 
 /**
@@ -31,7 +31,7 @@ export default class BrowserPageOpener {
     // coverage. There's no harm in this, and it avoids a coverage gap for a
     // condition that, by definition, would never execute when collecting
     // coverage. We could use a directive to ignore that gap, but why bother.
-    window[covKey] = createCoverageMap(window[covKey])
+    window[covKey] = libCoverage.createCoverageMap(window[covKey])
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "test-page-opener",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Enables an application's tests to open its own page URLs both in the browser and in Node.js using jsdom",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
After updating mbland/tomcat-servlet-testing-example to use v1.0.2, its tests failed with this error:

```text
FAIL  main.test.js [ main.test.js ]
SyntaxError: Named export 'createCoverageMap' not found. The requested module
'istanbul-lib-coverage' is a CommonJS module, which may not support all
module.exports as named exports.

CommonJS modules can always be imported via the default export, for example
using:

import pkg from 'istanbul-lib-coverage';
const { createCoverageMap } = pkg;
```

At least it was a very clear and straightforward message leading to an easy fix. Still, gah.